### PR TITLE
sysvsem php extension added

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -72,7 +72,8 @@ RUN docker-php-ext-install \
     pdo_mysql \
     soap \
     intl \
-    sockets
+    sockets \
+    sysvsem
 
 RUN php -m
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -67,7 +67,8 @@ RUN docker-php-ext-install \
     pdo_mysql \
     soap \
     intl \
-    sockets
+    sockets \
+    sysvsem
 
 RUN php -m
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@ Works well with Symfony, Laravel and Nette. Other frameworks should work too.
 
 ## Versions (tags)
 
-- `5.6` - deprecated, will be removed soon, security support end on 31 Dec 2018
-- `7.0` - deprecated, will be removed soon, security support end on 3 Dec 2018
-- `7.1`
-- `7.2`
-- `7.3`
+- `7.1` - deprecated, will be removed soon, security support end on 24 Oct 2019
+- `7.2` - deprecated, will be removed soon, security support end on 1 Oct 2020
+- `7.3` - deprecated, will be removed soon, security support end on 6 Dec 2021
 - `7.4`
 - `8.0`
 


### PR DESCRIPTION
`sysvsem` extension allow run this lock implementation: https://symfony.com/doc/current/components/lock.html#semaphorestore.

I test build of 7.4 php ant it run ok, but on php 8.0 i have problem with base 8.0 build:

```console
root@vojtadev:/var/www/htdocs/github/docker-test/docker-php-tests# docker build base-8.0/
Sending build context to Docker daemon  4.096kB
Step 1/10 : FROM php:8.0-alpine
 ---> cbd87967d02b
Step 2/10 : MAINTAINER Jakub Vyvazil <jakub@vyvazil.cz>
 ---> Using cache
 ---> a4fde40bc2d9
Step 3/10 : ENV NODE_VERSION 10.13.0
 ---> Using cache
 ---> 3125ae1dcbe0
Step 4/10 : ENV NPM_VERSION 7.11.2
 ---> Using cache
 ---> 62243b790782
Step 5/10 : RUN apk update && apk upgrade
 ---> Using cache
 ---> 25a608a12105
Step 6/10 : RUN apk add --update     git     openssh-client
 ---> Using cache
 ---> d3ae0b871ea4
Step 7/10 : RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ---> Using cache
 ---> b47d064becb8
Step 8/10 : RUN addgroup -g 1000 node     && adduser -u 1000 -G node -s /bin/sh -D node     && apk add --no-cache         libstdc++     && apk add --no-cache --virtual .build-deps         binutils-gold         curl         g++         gcc         gnupg         libgcc         linux-headers         make         python2   && for key in     94AE36675C464D64BAFA68DD7434390BDBE9B9C5     FD3A5288F042B6850C66B31F09FE44734EB7990E     71DCFD284A79C3B38668286BC97EC7A07EDE3FC1     DD8F2338BAE7501E3DD5AC78C273792F7D83545D     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8     B9AE9905FFD7803F25714661B63B535A4C206CA9     56730D5401028683275BD23C23EFEFE93C4CFFFE     77984A986EBC2AA786BC0F66B01FBB92821C587A     8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600   ; do     gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ||     gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" ||     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ;   done     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz"     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc     && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c -     && tar -xf "node-v$NODE_VERSION.tar.xz"     && cd "node-v$NODE_VERSION"     && ./configure     && make -j$(getconf _NPROCESSORS_ONLN)     && make install     && apk del .build-deps     && cd ..     && rm -Rf "node-v$NODE_VERSION"     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 ---> Running in c302f10a4775
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/2) Installing libgcc (10.3.1_git20210424-r2)
(2/2) Installing libstdc++ (10.3.1_git20210424-r2)
OK: 30 MiB in 41 packages
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/41) Installing binutils-gold (2.35.2-r2)
(2/41) Installing binutils (2.35.2-r2)
(3/41) Installing libgomp (10.3.1_git20210424-r2)
(4/41) Installing libatomic (10.3.1_git20210424-r2)
(5/41) Installing libgphobos (10.3.1_git20210424-r2)
(6/41) Installing gmp (6.2.1-r0)
(7/41) Installing isl22 (0.22-r0)
(8/41) Installing mpfr4 (4.1.0-r0)
(9/41) Installing mpc1 (1.2.1-r0)
(10/41) Installing gcc (10.3.1_git20210424-r2)
(11/41) Installing musl-dev (1.2.2-r3)
(12/41) Installing libc-dev (0.7.2-r3)
(13/41) Installing g++ (10.3.1_git20210424-r2)
(14/41) Installing libgpg-error (1.42-r0)
(15/41) Installing libassuan (2.5.5-r0)
(16/41) Installing libcap (2.50-r0)
(17/41) Installing libffi (3.3-r2)
(18/41) Installing libintl (0.21-r0)
(19/41) Installing libblkid (2.37.2-r0)
(20/41) Installing libmount (2.37.2-r0)
(21/41) Installing pcre (8.44-r0)
(22/41) Installing glib (2.68.3-r0)
(23/41) Installing libgcrypt (1.9.4-r0)
(24/41) Installing libsecret (0.20.4-r1)
(25/41) Installing pinentry (1.1.1-r0)
Executing pinentry-1.1.1-r0.post-install
(26/41) Installing libbz2 (1.0.8-r1)
(27/41) Installing nettle (3.7.3-r0)
(28/41) Installing p11-kit (0.23.22-r0)
(29/41) Installing libtasn1 (4.17.0-r0)
(30/41) Installing libunistring (0.9.10-r1)
(31/41) Installing gnutls (3.7.1-r0)
(32/41) Installing libksba (1.5.1-r0)
(33/41) Installing gdbm (1.19-r0)
(34/41) Installing libsasl (2.1.27-r12)
(35/41) Installing libldap (2.4.58-r0)
(36/41) Installing npth (1.6-r0)
(37/41) Installing gnupg (2.2.31-r0)
(38/41) Installing linux-headers (5.10.41-r0)
(39/41) Installing make (4.3-r0)
(40/41) Installing python2 (2.7.18-r2)
(41/41) Installing .build-deps (20211129.180428)
Executing busybox-1.33.1-r6.trigger
OK: 276 MiB in 82 packages
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: keyserver receive failed: No name
gpg: keyserver receive failed: No name
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 7434390BDBE9B9C5: public key "Colin Ihrig <cjihrig@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: keyserver receive failed: No name
gpg: keyserver receive failed: No name
gpg: key 09FE44734EB7990E: public key "Jeremiah Senkpiel <fishrock123@rocketmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: keyserver receive failed: No name
gpg: keyserver receive failed: No name
gpg: key C97EC7A07EDE3FC1: public key "keybase.io/jasnell <jasnell@keybase.io>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: keyserver receive failed: No name
gpg: keyserver receive failed: No name
gpg: key C273792F7D83545D: public key "Rod Vagg <rod@vagg.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: keyserver receive failed: No name
gpg: keyserver receive failed: No name
gpg: key E73BC641CC11F4C8: public key "Myles Borins <myles.borins@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: keyserver receive failed: No name
gpg: keyserver receive failed: No name
gpg: key B63B535A4C206CA9: public key "Evan Lucas <evanlucas@me.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: keyserver receive failed: No name
gpg: keyserver receive failed: No name
gpg: key 23EFEFE93C4CFFFE: public key "Italo A. Casas <me@italoacasas.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: keyserver receive failed: No name
gpg: keyserver receive failed: No name
gpg: key B01FBB92821C587A: public key "Gibson Fahnestock <gibfahn@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: keyserver receive failed: No name
gpg: keyserver receive failed: No name
gpg: key 770F7A9A5AE15600: public key "MichaĂŤl Zasso (Targos) <targos@protonmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: Signature made Tue Oct 30 08:45:52 2018 UTC
gpg:                using RSA key 0EFFE1BCEFD9C84E3D098152933B01F40B5CA946
gpg: Good signature from "Myles Borins <myles.borins@gmail.com>" [unknown]
gpg:                 aka "Myles Borins <mborins@google.com>" [unknown]
gpg:                 aka "Myles Borins <mylesborins@google.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: C4F0 DFFF 4E8C 1A82 3640  9D08 E73B C641 CC11 F4C8
     Subkey fingerprint: 0EFF E1BC EFD9 C84E 3D09  8152 933B 01F4 0B5C A946
node-v10.13.0.tar.xz: OK
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
creating icu_config.gypi
* Using ICU in deps/icu-small
creating icu_config.gypi
{ 'target_defaults': { 'cflags': [],
                       'default_configuration': 'Release',
                       'defines': [],
                       'include_dirs': [],
                       'libraries': []},
  'variables': { 'asan': 0,
                 'build_v8_with_gn': 'false',
                 'coverage': 'false',
                 'debug_nghttp2': 'false',
                 'enable_lto': 'false',
                 'enable_pgo_generate': 'false',
                 'enable_pgo_use': 'false',
                 'force_dynamic_crt': 0,
                 'gas_version': '2.35',
                 'host_arch': 'x64',
                 'icu_data_in': '../../deps/icu-small/source/data/in/icudt62l.dat',
                 'icu_endianness': 'l',
                 'icu_gyp_path': 'tools/icu/icu-generic.gyp',
                 'icu_locales': 'en,root',
                 'icu_path': 'deps/icu-small',
                 'icu_small': 'true',
                 'icu_ver_major': '62',
                 'llvm_version': 0,
                 'node_byteorder': 'little',
                 'node_debug_lib': 'false',
                 'node_enable_d8': 'false',
                 'node_enable_v8_vtunejit': 'false',
                 'node_install_npm': 'true',
                 'node_module_version': 64,
                 'node_no_browser_globals': 'false',
                 'node_prefix': '/usr/local',
                 'node_release_urlbase': '',
                 'node_shared': 'false',
                 'node_shared_cares': 'false',
                 'node_shared_http_parser': 'false',
                 'node_shared_libuv': 'false',
                 'node_shared_nghttp2': 'false',
                 'node_shared_openssl': 'false',
                 'node_shared_zlib': 'false',
                 'node_tag': '',
                 'node_target_type': 'executable',
                 'node_use_bundled_v8': 'true',
                 'node_use_dtrace': 'false',
                 'node_use_etw': 'false',
                 'node_use_openssl': 'true',
                 'node_use_pch': 'false',
                 'node_use_perfctr': 'false',
                 'node_use_v8_platform': 'true',
                 'node_with_ltcg': 'false',
                 'node_without_node_options': 'false',
                 'openssl_fips': '',
                 'openssl_no_asm': 0,
                 'shlib_suffix': 'so.64',
                 'target_arch': 'x64',
                 'v8_enable_gdbjit': 0,
                 'v8_enable_i18n_support': 1,
                 'v8_enable_inspector': 1,
                 'v8_no_strict_aliasing': 1,
                 'v8_optimized_debug': 0,
                 'v8_promise_internal_field_count': 1,
                 'v8_random_seed': 0,
                 'v8_trace_maps': 0,
                 'v8_typed_array_max_size_in_heap': 0,
                 'v8_use_snapshot': 'true',
                 'want_separate_host_toolset': 0}}
creating config.gypi
creating config.status
creating config.mk
running:
    python tools/gyp_node.py --no-parallel -f make-linux
make: /bin/sh: Operation not permitted
make: /bin/sh: Operation not permitted
make: /bin/sh: Operation not permitted
make: /bin/sh: Operation not permitted
make: /bin/sh: Operation not permitted
make: uname: Operation not permitted
make: uname: Operation not permitted
make: uname: Operation not permitted
make: uname: Operation not permitted
make: uname: Operation not permitted
make: uname: Operation not permitted
make: uname: Operation not permitted
make: uname: Operation not permitted
make: /usr/bin/python2.7: Operation not permitted
make: /usr/bin/python2.7: Operation not permitted
make: /usr/bin/python2.7: Operation not permitted
make: /bin/sh: Operation not permitted
make: /usr/bin/python2.7: Operation not permitted
make: /bin/sh: Operation not permitted
make: /usr/bin/python2.7: Operation not permitted
make: /usr/bin/python2.7: Operation not permitted
make: /bin/sh: Operation not permitted
make: /usr/bin/python2.7: Operation not permitted
make: /bin/sh: Operation not permitted
make: /usr/bin/python2.7: Operation not permitted
make: /bin/sh: Operation not permitted
make: /bin/sh: Operation not permitted
make: /usr/bin/python2.7: Operation not permitted
make: /bin/sh: Operation not permitted
make: /bin/sh: Operation not permitted
make: /bin/sh: Operation not permitted
make: find: Operation not permitted
make -C out BUILDTYPE=Release V=1
make: make: Operation not permitted
make: *** [Makefile:99: node] Error 127
The command '/bin/sh -c addgroup -g 1000 node     && adduser -u 1000 -G node -s /bin/sh -D node     && apk add --no-cache         libstdc++     && apk add --no-cache --virtual .build-deps         binutils-gold         curl         g++         gcc         gnupg         libgcc         linux-headers         make         python2   && for key in     94AE36675C464D64BAFA68DD7434390BDBE9B9C5     FD3A5288F042B6850C66B31F09FE44734EB7990E     71DCFD284A79C3B38668286BC97EC7A07EDE3FC1     DD8F2338BAE7501E3DD5AC78C273792F7D83545D     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8     B9AE9905FFD7803F25714661B63B535A4C206CA9     56730D5401028683275BD23C23EFEFE93C4CFFFE     77984A986EBC2AA786BC0F66B01FBB92821C587A     8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600   ; do     gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ||     gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" ||     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ;   done     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz"     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc     && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c -     && tar -xf "node-v$NODE_VERSION.tar.xz"     && cd "node-v$NODE_VERSION"     && ./configure     && make -j$(getconf _NPROCESSORS_ONLN)     && make install     && apk del .build-deps     && cd ..     && rm -Rf "node-v$NODE_VERSION"     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt' returned a non-zero code: 2
root@vojtadev:/var/www/htdocs/github/docker-test/docker-php-tests#
```

I have no idea what cause `Operation not permitted`.