### PR TITLE
php 8.2 docker file added

### DIFF
--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,0 +1,80 @@
+FROM nofutur3/php-tests:base-8.2
+
+MAINTAINER Jakub Vyvazil <jakub@vyvazil.cz>
+
+# install libs
+RUN apk add --update --no-cache \
+        icu-libs \
+        libintl \
+        libzip \
+        aria2 \
+        patch
+
+RUN apk add --update --no-cache --virtual .deps \
+        freetype-dev \
+        libjpeg-turbo-dev \
+        libpng-dev \
+        gettext-dev \
+        gmp-dev \
+        icu-dev \
+        oniguruma-dev \
+        libxml2-dev \
+        ldb-dev \
+        libzip-dev \
+        autoconf \
+        g++ \
+        make \
+        pcre-dev \
+        wget
+
+# GD extension
+RUN apk add --no-cache freetype libpng libjpeg-turbo freetype-dev libpng-dev libjpeg-turbo-dev && \
+  docker-php-ext-configure gd \
+  && NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
+  docker-php-ext-install -j${NPROC} gd && \
+  apk del --no-cache freetype-dev libpng-dev libjpeg-turbo-dev
+
+# iconv magic
+RUN apk add --no-cache --virtual .iconv-deps \
+    g++ \
+    gcc \
+    make &&\
+    mkdir iconv_build
+
+RUN wget https://ftp.wrz.de/pub/gnu/libiconv/libiconv-1.15.tar.gz --output-document=iconv_build/libiconv-1.15.tar.gz &&\
+    tar xvzf iconv_build/libiconv-1.15.tar.gz -C iconv_build/
+
+
+WORKDIR "/iconv_build/libiconv-1.15"
+RUN ./configure --prefix=/usr --enable-extra-encodings &&\
+    make &&\
+    make install
+WORKDIR "/"
+
+RUN rm iconv_build -r && apk del .iconv-deps
+
+# zip extension
+RUN docker-php-ext-configure zip && docker-php-ext-install zip
+
+# bcmath extension
+RUN docker-php-ext-configure bcmath --enable-bcmath && docker-php-ext-install bcmath
+
+# install php extensions
+RUN docker-php-ext-install \
+    #iconv \
+    mbstring \
+    pdo \
+    pdo_mysql \
+    soap \
+    intl \
+    sockets \
+    sysvsem
+
+RUN php -m
+
+RUN apk del .deps && \
+    rm -rf /var/cache/apk/*
+
+#iconv xtra encodings workaround
+#RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing gnu-libiconv
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Works well with Symfony, Laravel and Nette. Other frameworks should work too.
 - `7.1` - deprecated, will be removed soon, security support end on 24 Oct 2019
 - `7.2` - deprecated, will be removed soon, security support end on 1 Oct 2020
 - `7.3` - deprecated, will be removed soon, security support end on 6 Dec 2021
-- `7.4`
+- `7.4` - deprecated, will be removed soon, security support end on 28 Nov 2022
 - `8.0`
 - `8.1`
+- `8.2`
 
 ## Libraries
 

--- a/base-8.2/Dockerfile
+++ b/base-8.2/Dockerfile
@@ -1,0 +1,93 @@
+FROM php:8.2-alpine
+
+MAINTAINER Jakub Vyvazil <jakub@vyvazil.cz>
+
+ENV NODE_VERSION 14.18.2
+ENV NPM_VERSION 7.11.2
+
+# update libs
+RUN apk update && apk upgrade
+
+# install libs
+RUN apk add --update \
+    git \
+    openssh-client
+
+# install composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# install latest node
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="7a1a1a18e51ad20245fc366a0848cdb55e968094c807a094555ec2c214e8e9c6" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+# Install npm & upgrade to latest version
+RUN npm install -g npm@$NPM_VERSION
+
+# Install yarn
+RUN npm install -g yarn


### PR DESCRIPTION
I make test build and base8.2 dockerfile runs OK, but 8.2 final file failed on:

```console
Step 5/17 : RUN apk add --no-cache freetype libpng libjpeg-turbo freetype-dev libpng-dev libjpeg-turbo-dev &&   docker-php-ext-configure gd   && NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) &&   docker-php-ext-install -j${NPROC} gd &&   apk del --no-cache freetype-dev libpng-dev libjpeg-turbo-dev
 ---> Running in 2415bd8a17d1
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz
OK: 386 MiB in 124 packages
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz
(1/6) Installing dpkg-dev (1.21.9-r0)
(2/6) Installing dpkg (1.21.9-r0)
(3/6) Installing libmagic (5.43-r0)
(4/6) Installing file (5.43-r0)
(5/6) Installing re2c (3.0-r0)
(6/6) Installing .phpize-deps-configure (20221209.194759)
Executing busybox-1.35.0-r29.trigger
OK: 398 MiB in 130 packages
grep: /usr/local/include/php/main/php.h: No such file or directory
grep: /usr/local/include/php/Zend/zend_modules.h: No such file or directory
grep: /usr/local/include/php/Zend/zend_extensions.h: No such file or directory
```

I figure out than base image was build incorrectly, installation of node fucked up /usr/local/include/ directory somehow (even `ls -al /usr/local/include` failed in base image test build):

```console
Step 8/11 : RUN addgroup -g 1000 node     && adduser -u 1000 -G node -s /bin/sh -D node     && apk add --no-cache         libstdc++     && apk add --no-cache --virtual .build-deps         curl     && ARCH= && alpineArch="$(apk --print-arch)"       && case "${alpineArch##*-}" in         x86_64)           ARCH='x64'           CHECKSUM="7a1a1a18e51ad20245fc366a0848cdb55e968094c807a094555ec2c214e8e9c6"           ;;         *) ;;       esac   && if [ -n "${CHECKSUM}" ]; then     set -eu;     curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz";     echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c -       && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner       && ln -s /usr/local/bin/node /usr/local/bin/nodejs;   else     echo "Building from source"     && apk add --no-cache --virtual .build-deps-full         binutils-gold         g++         gcc         gnupg         libgcc         linux-headers         make         python3     && for key in       4ED778F539E3634C779C87C6D7062848A1AB005C       94AE36675C464D64BAFA68DD7434390BDBE9B9C5       74F12602B6F1C4E913FAA37AD3A89613643B6201       71DCFD284A79C3B38668286BC97EC7A07EDE3FC1       8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600       C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8       C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C       DD8F2338BAE7501E3DD5AC78C273792F7D83545D       A48C2BEE680E841632CD4E44F07496B3EB3C1762       108F52B48DB57BB0CC439B2997B01419BD92F80A       B9E2F5981AA6E0CD28160D9FF13993A75599653C     ; do       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" ||       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ;     done     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz"     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc     && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c -     && tar -xf "node-v$NODE_VERSION.tar.xz"     && cd "node-v$NODE_VERSION"     && ./configure     && make -j$(getconf _NPROCESSORS_ONLN) V=     && make install     && apk del .build-deps-full     && cd ..     && rm -Rf "node-v$NODE_VERSION"     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt;   fi   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"   && apk del .build-deps   && node --version   && npm --version
 ---> Running in bb729d3ef52c
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz
(1/1) Installing libstdc++ (12.2.1_git20220924-r4)
OK: 30 MiB in 43 packages
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz
(1/1) Installing .build-deps (20221209.194608)
OK: 30 MiB in 44 packages
node-v14.18.2-linux-x64-musl.tar.xz: OK
(1/1) Purging .build-deps (20221209.194608)
OK: 30 MiB in 43 packages
v14.18.2
6.14.15
Removing intermediate container bb729d3ef52c
 ---> 39f5e26e32fa
Step 9/11 : RUN ls -al /usr/local/include
 ---> Running in de7708f75253
ls: /usr/local/include/php: No such file or directory
```

I hope than include directory error is caused only by my local virtual machine and build in general is fine, because i do not have idea what go wrong. Looks than installation of node as biggest pain works.