### PR TITLE
docker-php-ext-enable sockets

### DIFF
--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -59,6 +59,8 @@ RUN docker-php-ext-configure zip && docker-php-ext-install zip
 # bcmath extension
 RUN docker-php-ext-configure bcmath --enable-bcmath && docker-php-ext-install bcmath
 
+RUN docker-php-ext-install sockets && docker-php-ext-configure sockets && docker-php-ext-enable sockets
+
 # install php extensions
 RUN docker-php-ext-install \
     #iconv \
@@ -67,7 +69,6 @@ RUN docker-php-ext-install \
     pdo_mysql \
     soap \
     intl \
-    sockets \
     sysvsem
 
 RUN php -m


### PR DESCRIPTION
I guess this should help, because sockets are not enabled in pipeline, so I hope that docker-php-ext-enable will work. Or maybe build it like this https://github.com/fballiano/docker-magento2/issues/38#issuecomment-584044481 .