### PR TITLE
phive added and global composer instaled by phive

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Works well with Symfony, Laravel and Nette. Other frameworks should work too.
 - NPM
 - YARN
 - Composer
+- Phive
 
 ## Extensions
 

--- a/base-8.2/Dockerfile
+++ b/base-8.2/Dockerfile
@@ -11,11 +11,20 @@ RUN apk update && apk upgrade
 # install libs
 RUN apk add --update \
     git \
-    openssh-client
+    openssh-client \
+    gnupg
+
+# install phive
+RUN wget -O phive.phar "https://phar.io/releases/phive.phar" \
+    && wget -O phive.phar.asc "https://phar.io/releases/phive.phar.asc" \
+    && gpg --keyserver hkps://keys.openpgp.org --recv-keys 0x6AF725270AB81E04D79442549D8A98B29B2D5D79 \
+    && gpg --verify phive.phar.asc phive.phar \
+    && rm phive.phar.asc \
+    && chmod +x phive.phar \
+    && mv phive.phar /usr/local/bin/phive
 
 # install composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer1 --1
+RUN phive install -g composer --trust-gpg-keys CBB3D576F2A0946F
 
 # install latest node
 RUN addgroup -g 1000 node \
@@ -45,7 +54,6 @@ RUN addgroup -g 1000 node \
         binutils-gold \
         g++ \
         gcc \
-        gnupg \
         libgcc \
         linux-headers \
         make \


### PR DESCRIPTION
I added `phive` for more reliable development dependencies like phpstan, ...

For example if phpstan is installed by composer with all package dependencies, developer can use some development dependency class in application code by mistake and with default `composer install` on local will not notice any errors, after application deploy on some environment with `composer install --no-dev` app can crash.

I also removed composer1 from docker build, if someone need different composer version, composer can be installed by `phive` as project dependency same as phpstan or phpunit, ...